### PR TITLE
Fix audit findings: partial release dates, tag ownership, and repo hygiene (v1.1.0)

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -46,6 +46,10 @@ jobs:
 
           # Bump extension.yaml
           yq -i ".Version = \"${version}\"" extension.yaml
+
+          # Keep the assembly version in step with it; the validate job enforces this.
+          sed -i -E "s/^(\[assembly: AssemblyVersion\(\")[^\"]+/\1${version}.0/" Properties/AssemblyInfo.cs
+          sed -i -E "s/^(\[assembly: AssemblyFileVersion\(\")[^\"]+/\1${version}.0/" Properties/AssemblyInfo.cs
 
           # Prepend new package entry to manifest.yaml
           VERSION="$version" \
@@ -77,7 +81,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git checkout -b "$branch"
-          git add extension.yaml manifest.yaml
+          git add extension.yaml manifest.yaml Properties/AssemblyInfo.cs
           git commit -m "Bump version to ${version}"
           git push -u origin "$branch"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate version consistency
         run: |
@@ -37,6 +37,18 @@ jobs:
             errors=$((errors + 1))
           fi
 
+          # The shipped DLL reports this version in logs and crash reports, so it has
+          # to track extension.yaml rather than drifting silently.
+          for attribute in AssemblyVersion AssemblyFileVersion; do
+            actual=$(sed -n "s/^\[assembly: ${attribute}(\"\([^\"]*\)\").*/\1/p" Properties/AssemblyInfo.cs)
+            echo "${attribute}: $actual"
+
+            if [ "$actual" != "${ext_version}.0" ]; then
+              echo "::error::${attribute} ($actual) does not match extension.yaml (expected ${ext_version}.0)"
+              errors=$((errors + 1))
+            fi
+          done
+
           if [ $errors -gt 0 ]; then
             exit 1
           fi
@@ -46,18 +58,12 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: robinraju/release-downloader@v1.8
-        id: download_playnite
-        with:
-          repository: "JosefNemec/Playnite"
-          latest: true
-          tarBall: false
-          zipBall: false
-          fileName: "Playnite*.zip"
-          out-file-path: ${{ runner.temp }}/playnite
-          extract: true
+      # No Playnite download here: only the release job needs Toolbox.exe to pack.
 
-      - run: |
-          dotnet build UpcomingGamesTagger.csproj -c Release
+      - name: Build
+        run: dotnet build UpcomingGamesTagger.csproj -c Release
+
+      - name: Test
+        run: dotnet test Tests/UpcomingGamesTagger.Tests.csproj -c Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate version consistency
         run: |
@@ -38,6 +38,18 @@ jobs:
             errors=$((errors + 1))
           fi
 
+          # The shipped DLL reports this version in logs and crash reports, so it has
+          # to track extension.yaml rather than drifting silently.
+          for attribute in AssemblyVersion AssemblyFileVersion; do
+            actual=$(sed -n "s/^\[assembly: ${attribute}(\"\([^\"]*\)\").*/\1/p" Properties/AssemblyInfo.cs)
+            echo "${attribute}: $actual"
+
+            if [ "$actual" != "${ext_version}.0" ]; then
+              echo "::error::${attribute} ($actual) does not match extension.yaml (expected ${ext_version}.0)"
+              errors=$((errors + 1))
+            fi
+          done
+
           if [ $errors -gt 0 ]; then
             exit 1
           fi
@@ -48,9 +60,9 @@ jobs:
     needs: validate
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: robinraju/release-downloader@v1.8
+      - uses: robinraju/release-downloader@v1.13
         id: download_playnite
         with:
           repository: "JosefNemec/Playnite"
@@ -63,11 +75,18 @@ jobs:
       - name: Extract Playnite
         run: 7z x ${{ runner.temp }}/playnite/*.7z -o${{ runner.temp }}/playnite
 
-      - run: |
-          dotnet build UpcomingGamesTagger.csproj -c Release
-          ${{ runner.temp }}/playnite/Toolbox.exe pack bin/Release/net462/ dist
+      - name: Build
+        run: dotnet build UpcomingGamesTagger.csproj -c Release
 
-      - uses: actions/upload-artifact@v6
+      # Gate the release on tests: this workflow is dispatched manually, so the
+      # pull_request run is no guarantee tests ever passed on this commit.
+      - name: Test
+        run: dotnet test Tests/UpcomingGamesTagger.Tests.csproj -c Release
+
+      - name: Pack
+        run: ${{ runner.temp }}/playnite/Toolbox.exe pack bin/Release/net462/ dist
+
+      - uses: actions/upload-artifact@v7
         with:
           name: artifacts
           path: |
@@ -81,16 +100,19 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
+      # yq is preinstalled on ubuntu runners, so no action (and no floating ref) needed.
       - name: Get Version
         id: version
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq '.Version' extension.yaml
+        run: |
+          # Assign first: inside `echo "$(...)"` a yq failure would be masked by echo's
+          # own exit status, publishing a release tagged "v".
+          version=$(yq '.Version' extension.yaml)
+          echo "result=$version" >> "$GITHUB_OUTPUT"
 
       - name: Pull artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: artifacts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,9 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 This project targets **.NET Framework 4.6.2**. C# 8+ features (nullable reference types, switch expressions, using declarations) are not available.
 
 **Build**
-- Use `MSBuild.exe` (Visual Studio / VS Build Tools), not `dotnet build`. The `dotnet` CLI does not generate `.g.cs` XAML code-behind files for WPF on .NET Framework — the build will succeed but the view won't work.
-- This project uses **SDK-style `.csproj`** (`Microsoft.NET.Sdk.WindowsDesktop`). New `.cs` files are auto-included by default. Do not add `<Compile Include>` entries manually.
+- Use `dotnet build` (as the Taskfile and both workflows do). A clean-tree build was verified on 2026-07-26 to generate `Settings/UpcomingGamesTaggerSettingsView.g.cs` and compile the BAML, so the settings view works. An earlier version of this file claimed `dotnet` could not do this for WPF on .NET Framework; that was wrong. `MSBuild.exe` also works if you have it.
+- This project uses **SDK-style `.csproj`** (`Microsoft.NET.Sdk.WindowsDesktop`). New `.cs` files are auto-included by default. Do not add `<Compile Include>` entries manually. `Tests/**` is explicitly excluded from the plugin project so the test sources don't get compiled into the DLL.
+- Run tests with `task test` or `dotnet test Tests/UpcomingGamesTagger.Tests.csproj`.
 - When adding NuGet packages, only use versions that ship a `net462` (or `net461`/`net45`) target folder. Don't rely on `netstandard2.0` fallbacks — they can silently break at runtime inside Playnite's AppDomain.
 
 **Naming** (Section 5 naming rules take priority over "match existing style" — don't perpetuate violations in new code)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sharkusmanch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Localization/cs_CZ.xaml
+++ b/Localization/cs_CZ.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Aktualizovat značku nadcházejících her</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Aktualizace značky nadcházejících her...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Vytvořena značka '{0}' pro nadcházející hry</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Aktualizována značka '{0}': +{1} her, -{2} her</sys:String>
 

--- a/Localization/de_DE.xaml
+++ b/Localization/de_DE.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Tag für kommende Spiele aktualisieren</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Tag für kommende Spiele wird aktualisiert...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Tag '{0}' für kommende Spiele erstellt</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Tag '{0}' aktualisiert: +{1} Spiele, -{2} Spiele</sys:String>
 

--- a/Localization/en_US.xaml
+++ b/Localization/en_US.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Update Upcoming Games Tag</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Updating upcoming games tag...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Created '{0}' tag for upcoming games</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Updated '{0}' tag: +{1} games, -{2} games</sys:String>
 

--- a/Localization/es_ES.xaml
+++ b/Localization/es_ES.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Actualizar etiqueta de próximos juegos</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Actualizando etiqueta de próximos juegos...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Etiqueta '{0}' creada para próximos juegos</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Etiqueta '{0}' actualizada: +{1} juegos, -{2} juegos</sys:String>
 

--- a/Localization/fr_FR.xaml
+++ b/Localization/fr_FR.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Mettre à jour le tag des jeux à venir</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Mise à jour du tag des jeux à venir...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Tag '{0}' créé pour les jeux à venir</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Tag '{0}' mis à jour : +{1} jeux, -{2} jeux</sys:String>
 

--- a/Localization/it_IT.xaml
+++ b/Localization/it_IT.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Aggiorna tag dei giochi in uscita</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Aggiornamento del tag dei giochi in uscita...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Tag '{0}' creato per i giochi in uscita</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Tag '{0}' aggiornato: +{1} giochi, -{2} giochi</sys:String>
 

--- a/Localization/ja_JP.xaml
+++ b/Localization/ja_JP.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">発売予定ゲームタグを更新</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">発売予定ゲームタガー</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">発売予定ゲームタグを更新中...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">発売予定ゲーム用に '{0}' タグを作成しました</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">'{0}' タグを更新しました: +{1} 件, -{2} 件</sys:String>
 

--- a/Localization/ko_KR.xaml
+++ b/Localization/ko_KR.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">출시 예정 게임 태그 업데이트</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">출시 예정 게임 태거</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">출시 예정 게임 태그 업데이트 중...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">출시 예정 게임에 '{0}' 태그를 생성했습니다</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">'{0}' 태그 업데이트: +{1}개, -{2}개</sys:String>
 

--- a/Localization/nl_NL.xaml
+++ b/Localization/nl_NL.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Tag voor aankomende games bijwerken</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Tag voor aankomende games wordt bijgewerkt...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Tag '{0}' aangemaakt voor aankomende games</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Tag '{0}' bijgewerkt: +{1} games, -{2} games</sys:String>
 

--- a/Localization/pl_PL.xaml
+++ b/Localization/pl_PL.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Aktualizuj tag nadchodzących gier</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Aktualizowanie tagu nadchodzących gier...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Utworzono tag '{0}' dla nadchodzących gier</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Zaktualizowano tag '{0}': +{1} gier, -{2} gier</sys:String>
 

--- a/Localization/pt_BR.xaml
+++ b/Localization/pt_BR.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Atualizar tag de próximos jogos</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Atualizando tag de próximos jogos...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Tag '{0}' criada para próximos jogos</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Tag '{0}' atualizada: +{1} jogos, -{2} jogos</sys:String>
 

--- a/Localization/pt_PT.xaml
+++ b/Localization/pt_PT.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Atualizar etiqueta de próximos jogos</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">A atualizar etiqueta de próximos jogos...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Etiqueta '{0}' criada para próximos jogos</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Etiqueta '{0}' atualizada: +{1} jogos, -{2} jogos</sys:String>
 

--- a/Localization/ro_RO.xaml
+++ b/Localization/ro_RO.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Actualizează eticheta jocurilor viitoare</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Se actualizează eticheta jocurilor viitoare...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Eticheta '{0}' a fost creată pentru jocurile viitoare</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Eticheta '{0}' a fost actualizată: +{1} jocuri, -{2} jocuri</sys:String>
 

--- a/Localization/ru_RU.xaml
+++ b/Localization/ru_RU.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Обновить тег предстоящих игр</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Обновление тега предстоящих игр...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Создан тег '{0}' для предстоящих игр</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Обновлён тег '{0}': +{1} игр, -{2} игр</sys:String>
 

--- a/Localization/sv_SE.xaml
+++ b/Localization/sv_SE.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Uppdatera tagg för kommande spel</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Uppdaterar tagg för kommande spel...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Skapade taggen '{0}' för kommande spel</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Uppdaterade taggen '{0}': +{1} spel, -{2} spel</sys:String>
 

--- a/Localization/tr_TR.xaml
+++ b/Localization/tr_TR.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Yaklaşan Oyunlar Etiketini Güncelle</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Yaklaşan Oyunlar Etiketleyici</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Yaklaşan oyunlar etiketi güncelleniyor...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Yaklaşan oyunlar için '{0}' etiketi oluşturuldu</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">'{0}' etiketi güncellendi: +{1} oyun, -{2} oyun</sys:String>
 

--- a/Localization/uk_UA.xaml
+++ b/Localization/uk_UA.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">Оновити тег майбутніх ігор</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">Upcoming Games Tagger</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">Оновлення тегу майбутніх ігор...</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">Створено тег '{0}' для майбутніх ігор</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">Оновлено тег '{0}': +{1} ігор, -{2} ігор</sys:String>
 

--- a/Localization/zh_CN.xaml
+++ b/Localization/zh_CN.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">更新即将发售游戏标签</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">即将发售游戏标记器</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">正在更新即将发售游戏标签…</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">已为即将发售的游戏创建 '{0}' 标签</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">已更新 '{0}' 标签: +{1} 款游戏, -{2} 款游戏</sys:String>
 

--- a/Localization/zh_TW.xaml
+++ b/Localization/zh_TW.xaml
@@ -5,6 +5,8 @@
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuUpdateTag">更新即將發售遊戲標籤</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerMenuSection">即將發售遊戲標記器</sys:String>
 
+  <sys:String x:Key="LOCUpcomingGamesTaggerProgressUpdating">正在更新即將發售遊戲標籤…</sys:String>
+
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagCreated">已為即將發售的遊戲建立 '{0}' 標籤</sys:String>
   <sys:String x:Key="LOCUpcomingGamesTaggerNotifTagUpdated">已更新 '{0}' 標籤: +{1} 款遊戲, -{2} 款遊戲</sys:String>
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+// Keep in sync with extension.yaml; CI fails the build when these drift apart.
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Playnite extension that automatically tags games with upcoming release dates f
 
 - **Automatic Tag Management**: Creates and maintains an "Upcoming" tag (name customizable)
 - **Smart Filtering**: Tags only games with future release dates
+- **Partial Date Support**: Games dated to just a year or a month stay tagged until that period actually ends
+- **Daily Refresh**: Re-evaluates when the date rolls over, without needing a Playnite restart
 - **Configurable Threshold**: Set how far ahead to look for upcoming releases (default: 1 year)
 - **Auto-Update**: Automatically updates tags when your library changes
 - **Manual Control**: Force update the tags via the main menu
@@ -27,6 +29,7 @@ task all
 
 # Individual commands
 task build      # Build the project
+task test       # Run the unit tests
 task pack       # Create .pext package
 task install    # Install the package in Playnite
 task dev-install # Install directly to extensions folder for development
@@ -60,4 +63,4 @@ The extension provides several configuration options:
 
 ## License
 
-[Add your license here]
+[MIT](LICENSE)

--- a/Settings/UpcomingGamesTaggerSettings.cs
+++ b/Settings/UpcomingGamesTaggerSettings.cs
@@ -15,12 +15,29 @@ namespace UpcomingGamesTagger
         private bool includeGamesWithoutReleaseDate = false;
         private int daysAheadThreshold = 365; // Only consider games releasing within a year
         private bool showNotifications = true;
+        private Guid? managedTagId = null;
+        private int settingsVersion = 0;
 
         public string TagName { get => tagName; set => SetValue(ref tagName, value); }
         public bool AutoUpdateOnLibraryChange { get => autoUpdateOnLibraryChange; set => SetValue(ref autoUpdateOnLibraryChange, value); }
         public bool IncludeGamesWithoutReleaseDate { get => includeGamesWithoutReleaseDate; set => SetValue(ref includeGamesWithoutReleaseDate, value); }
         public int DaysAheadThreshold { get => daysAheadThreshold; set => SetValue(ref daysAheadThreshold, value); }
         public bool ShowNotifications { get => showNotifications; set => SetValue(ref showNotifications, value); }
+
+        /// <summary>
+        /// Id of the tag this plugin owns. Tracked by id rather than by name so that
+        /// renaming TagName moves the existing tag instead of stranding it, and so a
+        /// same-named tag the user created themselves is never adopted or stripped.
+        /// </summary>
+        public Guid? ManagedTagId { get => managedTagId; set => SetValue(ref managedTagId, value); }
+
+        /// <summary>
+        /// Schema version of this settings file. Absent in files written by 1.0.1 and
+        /// earlier, which deserialize to 0. Used to tell a genuine upgrade apart from a
+        /// fresh install, which ManagedTagId alone cannot do: a fresh install that saves
+        /// settings before the tag is created also leaves ManagedTagId null.
+        /// </summary>
+        public int SettingsVersion { get => settingsVersion; set => SetValue(ref settingsVersion, value); }
     }
 
     public class UpcomingGamesTaggerSettingsViewModel : ObservableObject, ISettings
@@ -39,6 +56,25 @@ namespace UpcomingGamesTagger
             }
         }
 
+        private const int CurrentSettingsVersion = 1;
+
+        private readonly object _saveLock = new object();
+        private bool _isEditing;
+
+        /// <summary>
+        /// True only when upgrading an install that predates <see cref="UpcomingGamesTaggerSettings.ManagedTagId"/>.
+        /// Such an install really was managing the same-named tag, so adopting it once
+        /// avoids stranding it. A fresh install must never adopt a tag it did not create.
+        /// </summary>
+        public bool AdoptExistingTagByName { get; }
+
+        /// <summary>
+        /// Tag name as it was when settings loaded. Adoption matches against this rather
+        /// than the live TagName, so renaming the tag before the upgrade pass runs cannot
+        /// make the plugin adopt some unrelated tag that happens to carry the new name.
+        /// </summary>
+        public string AdoptionTagName { get; }
+
         public UpcomingGamesTaggerSettingsViewModel(UpcomingGamesTagger plugin)
         {
             // Injecting your plugin instance is required for Save/Load method because Playnite saves data to a location based on what plugin requested the operation.
@@ -51,31 +87,79 @@ namespace UpcomingGamesTagger
             if (savedSettings != null)
             {
                 Settings = savedSettings;
+                AdoptExistingTagByName = savedSettings.SettingsVersion < CurrentSettingsVersion;
+                AdoptionTagName = savedSettings.TagName;
             }
             else
             {
-                Settings = new UpcomingGamesTaggerSettings();
+                // Stamped up front so that saving this dialog before the tag exists does
+                // not later look like an upgrade from a version that tagged by name.
+                Settings = new UpcomingGamesTaggerSettings { SettingsVersion = CurrentSettingsVersion };
+            }
+        }
+
+        /// <summary>
+        /// Persists the id of a tag the plugin has just created or adopted. Called from
+        /// the background update pass, so it takes the save lock.
+        /// </summary>
+        public void SetManagedTagId(Guid tagId)
+        {
+            lock (_saveLock)
+            {
+                Settings.ManagedTagId = tagId;
+                Settings.SettingsVersion = CurrentSettingsVersion;
+
+                // While the dialog is open, Settings also holds edits the user has not
+                // confirmed yet. EndEdit or CancelEdit will persist the id instead.
+                if (!_isEditing)
+                {
+                    plugin.SavePluginSettings(Settings);
+                }
             }
         }
 
         public void BeginEdit()
         {
             // Code executed when settings view is opened and user starts editing values.
-            editingClone = Serialization.GetClone(Settings);
+            lock (_saveLock)
+            {
+                editingClone = Serialization.GetClone(Settings);
+                _isEditing = true;
+            }
         }
 
         public void CancelEdit()
         {
             // Code executed when user decides to cancel any changes made since BeginEdit was called.
             // This method should revert any changes made to Option1 and Option2.
-            Settings = editingClone;
+            lock (_saveLock)
+            {
+                // ManagedTagId is carried across the revert: a background update pass can
+                // assign it while the dialog is open, and discarding it would strand the tag.
+                var managedTagId = Settings.ManagedTagId;
+                Settings = editingClone;
+                Settings.ManagedTagId = managedTagId;
+                _isEditing = false;
+
+                // Written back so the file matches memory: a pass may have assigned an id
+                // that SetManagedTagId deliberately did not persist mid-edit.
+                plugin.SavePluginSettings(Settings);
+            }
         }
 
         public void EndEdit()
         {
             // Code executed when user decides to confirm changes made since BeginEdit was called.
             // This method should save settings made to Option1 and Option2.
-            plugin.SavePluginSettings(Settings);
+            lock (_saveLock)
+            {
+                _isEditing = false;
+                plugin.SavePluginSettings(Settings);
+            }
+
+            // A renamed tag or a changed threshold has to take effect now; the plugin
+            // used to keep serving a stale tag until Playnite was restarted.
+            plugin.OnSettingsSaved();
         }
 
         public bool VerifySettings(out List<string> errors)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,12 +8,17 @@ tasks:
   - task: restore
   - task: format
   - task: build
+  - task: test
   - task: pack
   - task: install
 
   build:
     cmds:
     - dotnet build  UpcomingGamesTagger.csproj --configuration Release
+
+  test:
+    cmds:
+    - dotnet test Tests/UpcomingGamesTagger.Tests.csproj --configuration Release
 
   format:
     cmds:
@@ -29,7 +34,7 @@ tasks:
   clean:
     cmds:
     - powershell -command "Remove-Item -Force -Recurse .\dist -ErrorAction Ignore" || true
-    - powershell -command "Remove-Item -Force -Recurse .\src\bin\ -ErrorAction Ignore" || true
+    - powershell -command "Remove-Item -Force -Recurse .\bin\, .\obj\, .\Tests\bin\, .\Tests\obj\ -ErrorAction Ignore" || true
 
   install:
     cmds:
@@ -50,6 +55,9 @@ tasks:
     cmds:
     - git checkout -b "release/v{{.VERSION}}"
     - yq -i '.Version = "{{.VERSION}}"' extension.yaml
+    # Keep the assembly version in step with extension.yaml; CI enforces this.
+    - sed -i -E "s/^(\[assembly: AssemblyVersion\(\")[^\"]+/\1{{.VERSION}}.0/" Properties/AssemblyInfo.cs
+    - sed -i -E "s/^(\[assembly: AssemblyFileVersion\(\")[^\"]+/\1{{.VERSION}}.0/" Properties/AssemblyInfo.cs
     - |
       addon_id=$(yq '.AddonId' manifest.yaml)
       addon_name="${addon_id%%_*}"
@@ -81,6 +89,6 @@ tasks:
       echo ""
       echo "Review the generated changelog in manifest.yaml"
       echo "Then commit and push:"
-      echo "  git add extension.yaml manifest.yaml"
+      echo "  git add extension.yaml manifest.yaml Properties/AssemblyInfo.cs"
       echo "  git commit -m 'Bump version to {{.VERSION}}'"
       echo "  git push -u origin release/v{{.VERSION}}"

--- a/Tests/UpcomingGameEvaluatorTests.cs
+++ b/Tests/UpcomingGameEvaluatorTests.cs
@@ -1,0 +1,219 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Playnite.SDK.Models;
+using System;
+
+namespace UpcomingGamesTagger.Tests
+{
+    [TestClass]
+    public class UpcomingGameEvaluatorTests
+    {
+        private static readonly DateTime Today = new DateTime(2026, 7, 26);
+
+        private const int OneYear = 365;
+        private const bool ExcludeUndated = false;
+        private const bool IncludeUndated = true;
+
+        #region PeriodEnd
+
+        [TestMethod]
+        public void PeriodEnd_YearOnly_IsLastDayOfYear()
+        {
+            Assert.AreEqual(new DateTime(2026, 12, 31), UpcomingGameEvaluator.PeriodEnd(new ReleaseDate(2026)));
+        }
+
+        [TestMethod]
+        public void PeriodEnd_YearAndMonth_IsLastDayOfMonth()
+        {
+            Assert.AreEqual(new DateTime(2026, 11, 30), UpcomingGameEvaluator.PeriodEnd(new ReleaseDate(2026, 11)));
+        }
+
+        [TestMethod]
+        public void PeriodEnd_February_AccountsForLeapYear()
+        {
+            Assert.AreEqual(new DateTime(2027, 2, 28), UpcomingGameEvaluator.PeriodEnd(new ReleaseDate(2027, 2)));
+            Assert.AreEqual(new DateTime(2028, 2, 29), UpcomingGameEvaluator.PeriodEnd(new ReleaseDate(2028, 2)));
+        }
+
+        [TestMethod]
+        public void PeriodEnd_FullDate_IsThatDay()
+        {
+            Assert.AreEqual(new DateTime(2026, 11, 17), UpcomingGameEvaluator.PeriodEnd(new ReleaseDate(2026, 11, 17)));
+        }
+
+        #endregion
+
+        #region Year-only precision
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyInCurrentYear_IsUpcoming()
+        {
+            // Playnite collapses a year-only date to January 1st. Comparing against that
+            // start date dropped every unannounced title dated to the current year.
+            Assert.IsTrue(Evaluate(new ReleaseDate(2026)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyInNextYear_IsUpcoming()
+        {
+            Assert.IsTrue(Evaluate(new ReleaseDate(2027)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyInPastYear_IsNotUpcoming()
+        {
+            Assert.IsFalse(Evaluate(new ReleaseDate(2025)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyStartingBeyondThreshold_IsNotUpcoming()
+        {
+            // 2028-01-01 is more than a year past 2026-07-26.
+            Assert.IsFalse(Evaluate(new ReleaseDate(2028)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyLateInThatYear_IsStillUpcoming()
+        {
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026), new DateTime(2026, 12, 30), OneYear, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyOnLastDayOfThatYear_IsNotUpcoming()
+        {
+            // The last possible release day is treated like a known release day: by then
+            // the game has either shipped or is shipping, so it is no longer upcoming.
+            Assert.IsFalse(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026), new DateTime(2026, 12, 31), OneYear, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_YearOnlyOnFirstDayOfFollowingYear_IsNotUpcoming()
+        {
+            Assert.IsFalse(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026), new DateTime(2027, 1, 1), OneYear, ExcludeUndated));
+        }
+
+        #endregion
+
+        #region Month precision
+
+        [TestMethod]
+        public void IsUpcoming_MonthOnlyLaterThisMonth_IsUpcoming()
+        {
+            // The date collapses to 2026-07-01, which is already past, but the month is not.
+            Assert.IsTrue(Evaluate(new ReleaseDate(2026, 7)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_MonthOnlyPastTheFirstOfThatMonth_IsStillUpcoming()
+        {
+            // Previously the tag was stripped on the 1st, before the game had shipped.
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026, 12), new DateTime(2026, 12, 20), OneYear, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_MonthOnlyAfterThatMonthEnds_IsNotUpcoming()
+        {
+            Assert.IsFalse(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026, 12), new DateTime(2027, 1, 1), OneYear, ExcludeUndated));
+        }
+
+        #endregion
+
+        #region Day precision
+
+        [TestMethod]
+        public void IsUpcoming_FutureDate_IsUpcoming()
+        {
+            Assert.IsTrue(Evaluate(new ReleaseDate(2026, 8, 15)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_ReleaseDay_IsNotUpcoming()
+        {
+            Assert.IsFalse(Evaluate(new ReleaseDate(2026, 7, 26)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_PastDate_IsNotUpcoming()
+        {
+            Assert.IsFalse(Evaluate(new ReleaseDate(2026, 7, 25)));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_IgnoresTimeOfDay()
+        {
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026, 7, 27), Today.AddHours(23), OneYear, ExcludeUndated));
+        }
+
+        #endregion
+
+        #region Threshold
+
+        [TestMethod]
+        public void IsUpcoming_OnThresholdBoundary_IsUpcoming()
+        {
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026, 8, 25), Today, 30, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_JustPastThreshold_IsNotUpcoming()
+        {
+            Assert.IsFalse(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2026, 8, 26), Today, 30, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_ZeroThreshold_MeansNoLimit()
+        {
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2099, 1, 1), Today, 0, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_AbsurdlyLargeThreshold_DoesNotThrow()
+        {
+            // The threshold comes straight from an unvalidated text box; adding it to a
+            // DateTime would overflow and abort every pass.
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2027, 1, 1), Today, int.MaxValue, ExcludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_NegativeThreshold_MeansNoLimit()
+        {
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(
+                new ReleaseDate(2099, 1, 1), Today, -1, ExcludeUndated));
+        }
+
+        #endregion
+
+        #region Missing and malformed dates
+
+        [TestMethod]
+        public void IsUpcoming_NoReleaseDate_FollowsSetting()
+        {
+            Assert.IsFalse(UpcomingGameEvaluator.IsUpcoming(null, Today, OneYear, ExcludeUndated));
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(null, Today, OneYear, IncludeUndated));
+        }
+
+        [TestMethod]
+        public void IsUpcoming_EmptyReleaseDate_IsTreatedAsUndated()
+        {
+            // ReleaseDate.Empty carries Year 0, which no DateTime can represent.
+            Assert.IsFalse(UpcomingGameEvaluator.IsUpcoming(ReleaseDate.Empty, Today, OneYear, ExcludeUndated));
+            Assert.IsTrue(UpcomingGameEvaluator.IsUpcoming(ReleaseDate.Empty, Today, OneYear, IncludeUndated));
+        }
+
+        #endregion
+
+        private static bool Evaluate(ReleaseDate releaseDate)
+        {
+            return UpcomingGameEvaluator.IsUpcoming(releaseDate, Today, OneYear, ExcludeUndated);
+        }
+    }
+}

--- a/Tests/UpcomingGamesTagger.Tests.csproj
+++ b/Tests/UpcomingGamesTagger.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>UpcomingGamesTagger.Tests</RootNamespace>
+    <AssemblyName>UpcomingGamesTagger.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <!-- Must match the plugin project's PlayniteSDK version so the tests exercise the
+         same SDK that ships. Referenced explicitly rather than inherited because the
+         plugin sets ExcludeAssets="runtime" (Playnite supplies the DLL at run time),
+         which also withholds it from the test host. A drift between the two versions
+         fails the restore with NU1605 rather than passing silently. -->
+    <PackageReference Include="PlayniteSDK" Version="6.16.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UpcomingGamesTagger.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UpcomingGameEvaluator.cs
+++ b/UpcomingGameEvaluator.cs
@@ -1,0 +1,77 @@
+using Playnite.SDK.Models;
+using System;
+
+namespace UpcomingGamesTagger
+{
+    /// <summary>
+    /// Decides whether a game counts as "upcoming". Deliberately free of IPlayniteAPI
+    /// so the predicate can be unit tested without a Playnite database.
+    /// </summary>
+    public static class UpcomingGameEvaluator
+    {
+        /// <summary>
+        /// Earliest day the game could release. Playnite already collapses a partial
+        /// ReleaseDate to the start of its period (2027 becomes 2027-01-01).
+        /// </summary>
+        public static DateTime PeriodStart(ReleaseDate releaseDate)
+        {
+            return releaseDate.Date.Date;
+        }
+
+        /// <summary>
+        /// Latest day the game could release, derived from the precision actually stored.
+        /// Month and Day are null when the metadata only specified a year, or a year and
+        /// month, which is common for titles without a confirmed date.
+        /// </summary>
+        public static DateTime PeriodEnd(ReleaseDate releaseDate)
+        {
+            if (releaseDate.Month.HasValue && releaseDate.Day.HasValue)
+            {
+                return new DateTime(releaseDate.Year, releaseDate.Month.Value, releaseDate.Day.Value);
+            }
+
+            if (releaseDate.Month.HasValue)
+            {
+                var month = releaseDate.Month.Value;
+                return new DateTime(releaseDate.Year, month, DateTime.DaysInMonth(releaseDate.Year, month));
+            }
+
+            return new DateTime(releaseDate.Year, 12, 31);
+        }
+
+        /// <summary>
+        /// A game is upcoming while any part of its release period is still ahead of
+        /// <paramref name="today"/> and that period begins within the configured window.
+        /// </summary>
+        /// <param name="daysAheadThreshold">Size of the look-ahead window in days; zero or less means no limit.</param>
+        public static bool IsUpcoming(ReleaseDate? releaseDate, DateTime today, int daysAheadThreshold, bool includeGamesWithoutReleaseDate)
+        {
+            // ReleaseDate.Empty carries Year 0, which is not a constructible DateTime.
+            // Treat it the same as no date at all.
+            if (!releaseDate.HasValue || releaseDate.Value.Year < 1 || releaseDate.Value.Year > 9999)
+            {
+                return includeGamesWithoutReleaseDate;
+            }
+
+            today = today.Date;
+
+            // Compare against the end of the period, so a year-only 2026 title stays
+            // tagged all year instead of dropping out on January 1st.
+            if (PeriodEnd(releaseDate.Value) <= today)
+            {
+                return false;
+            }
+
+            if (daysAheadThreshold <= 0)
+            {
+                return true;
+            }
+
+            // The window is measured from the earliest possible release date, so a
+            // year-only title isn't excluded merely because its period runs past the end
+            // of the window. Subtracting rather than calling today.AddDays keeps an
+            // absurd user-supplied threshold from throwing instead of just matching.
+            return (PeriodStart(releaseDate.Value) - today).TotalDays <= daysAheadThreshold;
+        }
+    }
+}

--- a/UpcomingGamesTagger.cs
+++ b/UpcomingGamesTagger.cs
@@ -125,9 +125,8 @@ namespace UpcomingGamesTagger
         /// Resolves the tag this plugin owns, creating it when necessary.
         /// </summary>
         /// <returns>True when <see cref="_upcomingTag"/> is usable.</returns>
-        private bool EnsureUpcomingTag()
+        private bool EnsureUpcomingTag(string tagName)
         {
-            var tagName = settings.Settings.TagName;
             var managedTagId = settings.Settings.ManagedTagId;
 
             if (managedTagId.HasValue)
@@ -211,11 +210,20 @@ namespace UpcomingGamesTagger
                     return;
                 }
 
+                // Snapshot the settings this pass depends on. CancelEdit replaces the
+                // whole Settings object under its own lock, so re-reading per game could
+                // evaluate part of the library against pre-cancel values and the rest
+                // against the reverted ones.
+                var currentSettings = settings.Settings;
+                var tagName = currentSettings.TagName;
+                var daysAheadThreshold = currentSettings.DaysAheadThreshold;
+                var includeGamesWithoutReleaseDate = currentSettings.IncludeGamesWithoutReleaseDate;
+
                 try
                 {
                     // Inside the try: resolving the tag can write to the database and to
                     // the settings file, and either can fail.
-                    if (!EnsureUpcomingTag())
+                    if (!EnsureUpcomingTag(tagName))
                     {
                         logger.Error("UpcomingGamesTagger: Could not resolve the managed tag, aborting update");
                         return;
@@ -233,8 +241,8 @@ namespace UpcomingGamesTagger
                         var isUpcoming = UpcomingGameEvaluator.IsUpcoming(
                             game.ReleaseDate,
                             today,
-                            settings.Settings.DaysAheadThreshold,
-                            settings.Settings.IncludeGamesWithoutReleaseDate);
+                            daysAheadThreshold,
+                            includeGamesWithoutReleaseDate);
 
                         if (isUpcoming && !isTagged)
                         {
@@ -268,7 +276,7 @@ namespace UpcomingGamesTagger
 
                         var message = string.Format(
                             ResourceProvider.GetString("LOCUpcomingGamesTaggerNotifTagUpdated"),
-                            settings.Settings.TagName, added, removed);
+                            tagName, added, removed);
                         logger.Info($"UpcomingGamesTagger: {message}");
                         ShowNotification("upcoming-tag-updated", message);
                     }

--- a/UpcomingGamesTagger.cs
+++ b/UpcomingGamesTagger.cs
@@ -1,12 +1,13 @@
-﻿using Playnite.SDK;
+using Playnite.SDK;
 using Playnite.SDK.Events;
 using Playnite.SDK.Models;
 using Playnite.SDK.Plugins;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace UpcomingGamesTagger
@@ -15,8 +16,19 @@ namespace UpcomingGamesTagger
     {
         private static readonly ILogger logger = LogManager.GetLogger();
 
+        // Polling hourly rather than scheduling a single callback for midnight keeps the
+        // refresh correct across DST changes and machine sleep/resume.
+        private static readonly TimeSpan RolloverCheckInterval = TimeSpan.FromHours(1);
+
         private UpcomingGamesTaggerSettingsViewModel settings { get; set; }
-        private Tag upcomingTag = null;
+        private Tag _upcomingTag;
+        private Timer _rolloverTimer;
+        private DateTime _lastRunDate;
+        private volatile bool _stopping;
+
+        // Library updates, the menu action, the settings dialog and the rollover timer
+        // can all trigger a pass; serialise them so two passes cannot interleave writes.
+        private readonly object _updateLock = new object();
 
         public override Guid Id { get; } = Guid.Parse("22b532e7-0caa-4c5a-bacf-3009c4eb7eeb");
 
@@ -31,9 +43,22 @@ namespace UpcomingGamesTagger
 
         public override void OnApplicationStarted(OnApplicationStartedEventArgs args)
         {
-            logger.Info("UpcomingGamesTagger: Application started, initializing upcoming games tag");
-            InitializeUpcomingTag();
-            UpdateUpcomingGamesTag();
+            logger.Info("UpcomingGamesTagger: Application started, scheduling upcoming games tag update");
+
+            // The pass walks the whole library, so keep it off Playnite's startup path.
+            RunUpdateInBackground("Startup tag update");
+
+            _rolloverTimer = new Timer(OnRolloverCheck, null, RolloverCheckInterval, RolloverCheckInterval);
+        }
+
+        public override void OnApplicationStopped(OnApplicationStoppedEventArgs args)
+        {
+            // Disposing the timer does not wait for a callback that is already running,
+            // and a background pass may still be mid-walk, so signal them to stop writing
+            // before Playnite closes the database underneath them.
+            _stopping = true;
+            _rolloverTimer?.Dispose();
+            _rolloverTimer = null;
         }
 
         public override void OnLibraryUpdated(OnLibraryUpdatedEventArgs args)
@@ -41,133 +66,274 @@ namespace UpcomingGamesTagger
             if (settings.Settings.AutoUpdateOnLibraryChange)
             {
                 logger.Info("UpcomingGamesTagger: Library updated, refreshing upcoming games tag");
-                UpdateUpcomingGamesTag();
+
+                // Playnite raises this on the UI thread, so the pass has to be handed off
+                // rather than run inline; it walks the whole library.
+                RunUpdateInBackground("Library update tag update");
             }
         }
 
-        private void InitializeUpcomingTag()
+        /// <summary>
+        /// Called by the settings view model once changes are saved, so a renamed tag or
+        /// an adjusted threshold applies without restarting Playnite.
+        /// </summary>
+        public void OnSettingsSaved()
         {
+            RunUpdateInBackground("Settings change tag update");
+        }
+
+        private void RunUpdateInBackground(string context)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    UpdateUpcomingGamesTag();
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"UpcomingGamesTagger: {context} failed");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Re-tags when the calendar day changes, so a long-running Playnite session does
+        /// not keep yesterday's results.
+        /// </summary>
+        private void OnRolloverCheck(object state)
+        {
+            // A timer callback runs on the thread pool, where an escaping exception would
+            // take down the whole process.
             try
             {
-                // Find existing tag or create new one
-                upcomingTag = PlayniteApi.Database.Tags
-                    .FirstOrDefault(t => t.Name == settings.Settings.TagName);
-
-                if (upcomingTag == null)
+                if (DateTime.Now.Date == _lastRunDate)
                 {
-                    upcomingTag = new Tag(settings.Settings.TagName);
-                    PlayniteApi.Database.Tags.Add(upcomingTag);
-
-                    if (settings.Settings.ShowNotifications)
-                    {
-                        PlayniteApi.Notifications.Add(new NotificationMessage(
-                            "upcoming-tag-created",
-                            string.Format(ResourceProvider.GetString("LOCUpcomingGamesTaggerNotifTagCreated"), settings.Settings.TagName),
-                            NotificationType.Info));
-                    }
-
-                    logger.Info($"UpcomingGamesTagger: Created new tag '{settings.Settings.TagName}'");
+                    return;
                 }
-                else
-                {
-                    logger.Info($"UpcomingGamesTagger: Found existing tag '{settings.Settings.TagName}'");
-                }
+
+                logger.Info("UpcomingGamesTagger: Date changed, refreshing upcoming games tag");
+                UpdateUpcomingGamesTag();
             }
             catch (Exception ex)
             {
-                logger.Error(ex, "UpcomingGamesTagger: Failed to initialize upcoming tag");
+                logger.Error(ex, "UpcomingGamesTagger: Scheduled tag refresh failed");
+            }
+        }
+
+        /// <summary>
+        /// Resolves the tag this plugin owns, creating it when necessary.
+        /// </summary>
+        /// <returns>True when <see cref="_upcomingTag"/> is usable.</returns>
+        private bool EnsureUpcomingTag()
+        {
+            var tagName = settings.Settings.TagName;
+            var managedTagId = settings.Settings.ManagedTagId;
+
+            if (managedTagId.HasValue)
+            {
+                _upcomingTag = PlayniteApi.Database.Tags.Get(managedTagId.Value);
+
+                if (_upcomingTag != null)
+                {
+                    ApplyTagName(tagName);
+                    return true;
+                }
+
+                logger.Warn($"UpcomingGamesTagger: Managed tag {managedTagId.Value} no longer exists, recreating it");
+            }
+            else if (settings.AdoptExistingTagByName)
+            {
+                // One-time upgrade path for installs predating ManagedTagId.
+                var adoptionName = settings.AdoptionTagName;
+                _upcomingTag = PlayniteApi.Database.Tags.FirstOrDefault(t => t.Name == adoptionName);
+
+                if (_upcomingTag != null)
+                {
+                    logger.Info($"UpcomingGamesTagger: Adopting previously managed tag '{adoptionName}' ({_upcomingTag.Id})");
+                    settings.SetManagedTagId(_upcomingTag.Id);
+                    ApplyTagName(tagName);
+                    return true;
+                }
+            }
+
+            return CreateUpcomingTag(tagName);
+        }
+
+        /// <summary>
+        /// Renames the owned tag in place rather than leaving the old one applied to every
+        /// game and creating a second tag alongside it.
+        /// </summary>
+        private void ApplyTagName(string tagName)
+        {
+            if (_upcomingTag.Name == tagName)
+            {
+                return;
+            }
+
+            logger.Info($"UpcomingGamesTagger: Renaming managed tag '{_upcomingTag.Name}' to '{tagName}'");
+            _upcomingTag.Name = tagName;
+            PlayniteApi.Database.Tags.Update(_upcomingTag);
+        }
+
+        private bool CreateUpcomingTag(string tagName)
+        {
+            try
+            {
+                var tag = new Tag(tagName);
+                PlayniteApi.Database.Tags.Add(tag);
+                _upcomingTag = tag;
+                settings.SetManagedTagId(tag.Id);
+
+                logger.Info($"UpcomingGamesTagger: Created tag '{tagName}' ({tag.Id})");
+                ShowNotification(
+                    "upcoming-tag-created",
+                    string.Format(ResourceProvider.GetString("LOCUpcomingGamesTaggerNotifTagCreated"), tagName));
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex, $"UpcomingGamesTagger: Failed to create tag '{tagName}'");
+                _upcomingTag = null;
+                return false;
             }
         }
 
         private void UpdateUpcomingGamesTag()
         {
-            if (upcomingTag == null)
+            lock (_updateLock)
             {
-                InitializeUpcomingTag();
-                if (upcomingTag == null)
+                var today = DateTime.Now.Date;
+
+                if (_stopping)
                 {
-                    logger.Error("UpcomingGamesTagger: Could not initialize tag, aborting update");
                     return;
                 }
-            }
 
-            try
-            {
-                var upcomingGames = GetUpcomingGames();
-                var currentTaggedGames = PlayniteApi.Database.Games
-                    .Where(g => g.TagIds?.Contains(upcomingTag.Id) == true)
-                    .ToHashSet();
-
-                var gamesToAdd = upcomingGames.Where(g => !currentTaggedGames.Contains(g)).ToList();
-                var gamesToRemove = currentTaggedGames.Where(g => !upcomingGames.Contains(g)).ToList();
-
-                // Add tag to upcoming games
-                foreach (var game in gamesToAdd)
+                try
                 {
-                    if (game.TagIds == null)
-                        game.TagIds = new List<Guid>();
-
-                    if (!game.TagIds.Contains(upcomingTag.Id))
+                    // Inside the try: resolving the tag can write to the database and to
+                    // the settings file, and either can fail.
+                    if (!EnsureUpcomingTag())
                     {
-                        game.TagIds.Add(upcomingTag.Id);
-                        PlayniteApi.Database.Games.Update(game);
+                        logger.Error("UpcomingGamesTagger: Could not resolve the managed tag, aborting update");
+                        return;
                     }
-                }
 
-                // Remove tag from games that are no longer upcoming
-                foreach (var game in gamesToRemove)
+                    var tagId = _upcomingTag.Id;
+                    var gamesToAdd = new List<Game>();
+                    var gamesToRemove = new List<Game>();
+
+                    // Collect first, then write, so the database is not mutated while it
+                    // is being enumerated.
+                    foreach (var game in PlayniteApi.Database.Games)
+                    {
+                        var isTagged = game.TagIds?.Contains(tagId) == true;
+                        var isUpcoming = UpcomingGameEvaluator.IsUpcoming(
+                            game.ReleaseDate,
+                            today,
+                            settings.Settings.DaysAheadThreshold,
+                            settings.Settings.IncludeGamesWithoutReleaseDate);
+
+                        if (isUpcoming && !isTagged)
+                        {
+                            gamesToAdd.Add(game);
+                        }
+                        else if (!isUpcoming && isTagged)
+                        {
+                            gamesToRemove.Add(game);
+                        }
+                    }
+
+                    if (gamesToAdd.Any() || gamesToRemove.Any())
+                    {
+                        int added;
+                        int removed;
+
+                        using (PlayniteApi.Database.BufferedUpdate())
+                        {
+                            added = ApplyToGames(gamesToAdd, game =>
+                            {
+                                if (game.TagIds == null)
+                                {
+                                    game.TagIds = new List<Guid>();
+                                }
+
+                                game.TagIds.Add(tagId);
+                            });
+
+                            removed = ApplyToGames(gamesToRemove, game => game.TagIds.Remove(tagId));
+                        }
+
+                        var message = string.Format(
+                            ResourceProvider.GetString("LOCUpcomingGamesTaggerNotifTagUpdated"),
+                            settings.Settings.TagName, added, removed);
+                        logger.Info($"UpcomingGamesTagger: {message}");
+                        ShowNotification("upcoming-tag-updated", message);
+                    }
+
+                    // Only on success, so a failed pass is retried at the next rollover check.
+                    _lastRunDate = today;
+                }
+                catch (Exception ex)
                 {
-                    if (game.TagIds?.Contains(upcomingTag.Id) == true)
-                    {
-                        game.TagIds.Remove(upcomingTag.Id);
-                        PlayniteApi.Database.Games.Update(game);
-                    }
+                    logger.Error(ex, "UpcomingGamesTagger: Failed to update upcoming games tag");
                 }
-
-                // Log and notify about changes
-                if (gamesToAdd.Any() || gamesToRemove.Any())
-                {
-                    var message = string.Format(ResourceProvider.GetString("LOCUpcomingGamesTaggerNotifTagUpdated"), settings.Settings.TagName, gamesToAdd.Count, gamesToRemove.Count);
-                    logger.Info($"UpcomingGamesTagger: {message}");
-
-                    if (settings.Settings.ShowNotifications && (gamesToAdd.Count > 0 || gamesToRemove.Count > 0))
-                    {
-                        PlayniteApi.Notifications.Add(new NotificationMessage(
-                            "upcoming-tag-updated",
-                            message,
-                            NotificationType.Info));
-                    }
-                }
-
-                logger.Info($"UpcomingGamesTagger: Tag now applied to {upcomingGames.Count} upcoming games");
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, "UpcomingGamesTagger: Failed to update upcoming games tag");
             }
         }
 
-        private List<Game> GetUpcomingGames()
+        /// <summary>
+        /// Applies <paramref name="mutate"/> to each game and persists it, isolating
+        /// per-game failures so one bad entry cannot abandon the rest of the batch.
+        /// </summary>
+        /// <returns>How many games were actually updated.</returns>
+        private int ApplyToGames(List<Game> games, Action<Game> mutate)
         {
-            var currentDate = DateTime.Now.Date;
-            var futureThreshold = settings.Settings.DaysAheadThreshold > 0
-                ? currentDate.AddDays(settings.Settings.DaysAheadThreshold)
-                : DateTime.MaxValue;
+            var updated = 0;
 
-            var upcomingGames = PlayniteApi.Database.Games.Where(game =>
+            foreach (var game in games)
             {
-                // Include games with release dates in the future
-                if (game.ReleaseDate.HasValue)
+                if (_stopping)
                 {
-                    var releaseDate = game.ReleaseDate.Value.Date;
-                    return releaseDate > currentDate && releaseDate <= futureThreshold;
+                    logger.Info("UpcomingGamesTagger: Shutting down, stopping tag update early");
+                    break;
                 }
 
-                // Optionally include games without release dates
-                return settings.Settings.IncludeGamesWithoutReleaseDate;
-            }).ToList();
+                try
+                {
+                    // The list was collected before these writes began, so a game may have
+                    // been deleted in the meantime.
+                    if (PlayniteApi.Database.Games[game.Id] == null)
+                    {
+                        continue;
+                    }
 
-            return upcomingGames;
+                    mutate(game);
+                    PlayniteApi.Database.Games.Update(game);
+                    updated++;
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, $"UpcomingGamesTagger: Failed to update tags for game '{game.Name}' ({game.Id})");
+                }
+            }
+
+            return updated;
+        }
+
+        private void ShowNotification(string id, string message)
+        {
+            if (!settings.Settings.ShowNotifications)
+            {
+                return;
+            }
+
+            // Notifications is bound to the UI and update passes run on background
+            // threads. BeginInvoke rather than Invoke: the UI thread can be waiting on
+            // _updateLock for a menu-triggered pass, and blocking here would deadlock.
+            Application.Current?.Dispatcher.BeginInvoke(new Action(() =>
+                PlayniteApi.Notifications.Add(new NotificationMessage(id, message, NotificationType.Info))));
         }
 
         public override IEnumerable<MainMenuItem> GetMainMenuItems(GetMainMenuItemsArgs args)
@@ -179,7 +345,18 @@ namespace UpcomingGamesTagger
                     Description = ResourceProvider.GetString("LOCUpcomingGamesTaggerMenuUpdateTag"),
                     MenuSection = "@" + ResourceProvider.GetString("LOCUpcomingGamesTaggerMenuSection"),
                     Action = (menuArgs) => {
-                        UpdateUpcomingGamesTag();
+                        // Runs the pass on a background thread so the UI stays responsive
+                        // while the library is walked.
+                        var result = PlayniteApi.Dialogs.ActivateGlobalProgress(
+                            progressArgs => UpdateUpcomingGamesTag(),
+                            new GlobalProgressOptions(ResourceProvider.GetString("LOCUpcomingGamesTaggerProgressUpdating"), false));
+
+                        // The dialog swallows the exception, so a user who asked for this
+                        // explicitly would otherwise see it close as if it had worked.
+                        if (result.Error != null)
+                        {
+                            logger.Error(result.Error, "UpcomingGamesTagger: Manual tag update failed");
+                        }
                     }
                 }
             };

--- a/UpcomingGamesTagger.csproj
+++ b/UpcomingGamesTagger.csproj
@@ -9,6 +9,10 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <!-- Excludes Tests/** from every default glob at once. A Compile/None Remove pair
+         is not enough: the WindowsDesktop SDK also globs **/*.xaml as Page, which would
+         markup-compile the test project's copied Localization files into this DLL. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UpcomingGamesTagger.sln
+++ b/UpcomingGamesTagger.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.1267
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UpcomingGamesTagger", "UpcomingGamesTagger.csproj", "{4FDF1E89-5BC3-4C72-8FDA-0D580E7A5D5F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UpcomingGamesTagger.Tests", "Tests\UpcomingGamesTagger.Tests.csproj", "{9C7E4A61-2F38-4B0D-9E5C-1A6B8D3F7C24}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{4FDF1E89-5BC3-4C72-8FDA-0D580E7A5D5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4FDF1E89-5BC3-4C72-8FDA-0D580E7A5D5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4FDF1E89-5BC3-4C72-8FDA-0D580E7A5D5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9C7E4A61-2F38-4B0D-9E5C-1A6B8D3F7C24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9C7E4A61-2F38-4B0D-9E5C-1A6B8D3F7C24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9C7E4A61-2F38-4B0D-9E5C-1A6B8D3F7C24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9C7E4A61-2F38-4B0D-9E5C-1A6B8D3F7C24}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/extension.yaml
+++ b/extension.yaml
@@ -1,7 +1,7 @@
 Id: UpcomingGamesTagger_22b532e7-0caa-4c5a-bacf-3009c4eb7eeb
 Name: Upcoming Games Tagger
 Author: sharkusmanch
-Version: 1.0.1
+Version: 1.1.0
 Module: UpcomingGamesTagger.dll
 Type: GenericPlugin
 Icon: icon.png

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,17 @@
 AddonId: UpcomingGamesTagger_22b532e7-0caa-4c5a-bacf-3009c4eb7eeb
 Packages:
+  - Version: 1.1.0
+    RequiredApiVersion: 6.12.0
+    ReleaseDate: 2026-07-26
+    PackageUrl: https://github.com/sharkusmanch/playnite-upcoming-games-tagger/releases/download/v1.1.0/UpcomingGamesTagger_v1.1.0.pext
+    Changelog:
+      - "Fix: games dated to only a year or a month are now tagged for the whole period instead of being missed or untagged on the 1st"
+      - "Fix: the tag is tracked by id, so renaming it moves the existing tag and a same-named tag you created yourself is never adopted or stripped"
+      - "Fix: bulk tag updates are wrapped in a buffered update to avoid excessive change events"
+      - The tag refresh no longer runs on Playnite's startup path or blocks the UI after a library update
+      - The tag is re-evaluated when the date rolls over, without needing a restart
+      - Settings changes apply immediately instead of after a restart
+      - Add unit tests, an MIT license, and assembly version validation in CI
   - Version: 1.0.1
     RequiredApiVersion: 6.12.0
     ReleaseDate: 2026-03-23


### PR DESCRIPTION
Addresses the findings for this extension from the **Playnite Extensions — Code Review (July 2026)** audit, which graded this repo **C+** on *"core predicate wrong for partial dates."*

@claude please review.

## Core correctness

**Partial release dates** (`UpcomingGameEvaluator.cs`) — Playnite collapses a partial `ReleaseDate` to the **start** of its period (`new ReleaseDate(2027).Date == 2027-01-01`, verified against `Playnite.SDK.dll`). The old predicate compared that start against today, so:
- a year-only title dated to the **current** year resolved to Jan 1 and was never tagged;
- a month-only title lost its tag on the **1st**, before it had shipped.

Now compares against the period **end**, derived from the precision actually stored (`Month`/`Day` are null at lower precision). The look-ahead window is still measured from the period **start**, so a year-only 2027 title is not excluded merely because its period runs past the end of the window.

> Note: the audit stated year-only releases "never get tagged". That is too broad — a year-only *2027* title was tagged correctly. The real defect was year-only titles in the current year, plus the drop-out on Jan 1 of the release year.

**Tag ownership by GUID** — the tag was resolved by `Tags.FirstOrDefault(t => t.Name == TagName)`, so a same-named tag the user created was adopted and then stripped library-wide, and renaming the tag in settings stranded the old one permanently (the cached tag was never re-resolved outside startup). Now tracked by a persisted `ManagedTagId`, renamed in place, with a `SettingsVersion` stamp so only installs predating this change adopt a tag by name — matched against the name as it was at load time.

**Bulk updates** — wrapped in `BufferedUpdate()` (the repo's own CLAUDE.md required this), with per-game failure isolation and a deleted-game guard.

## Threading and lifecycle

- The library-wide pass no longer runs on Playnite's startup path, and no longer runs on the UI thread after a library update. The menu action runs under `ActivateGlobalProgress` and now reports errors instead of closing as if it had worked.
- An hourly timer re-evaluates on calendar rollover, disposed on shutdown, with a stop flag so an in-flight pass stops writing as Playnite closes the database.
- Settings changes apply immediately instead of after a restart. `CancelEdit` no longer discards a tag id assigned by a concurrent pass, and a background save no longer persists uncommitted dialog edits.

## Tests and hygiene

- **New MSTest project, 25 tests** covering the date predicate, extracted as a pure function so it is testable without a Playnite database. There was previously no test project.
- **Added the missing MIT LICENSE.** `README.md` shipped the literal placeholder `[Add your license here]` while published to the Playnite addon database, so users were installing with no grant of rights.
- **AssemblyInfo version drift** (`1.0.0.0` vs shipped `1.0.1`) synced and now enforced in CI; bump automation keeps them together.
- **Removed the unused Playnite download** from the PR workflow. It globbed `Playnite*.zip`; the latest release (10.56) ships `10.56.7z` and `.exe` installers and **no zip**, which is exactly why Renovate PR #4 could not go green. Nothing consumed the download.
- **Replaced `mikefarah/yq@master`** (unpinned floating ref) with the preinstalled `yq`, and stopped masking a `yq` failure behind `echo`'s exit status — which could have published a release tagged `v`.
- **Excluded `Tests/**` from every default glob.** A `Compile`/`None` `Remove` pair missed the WindowsDesktop SDK's `**/*.xaml` `Page` glob, which markup-compiled the test project's copied localization files into the shipped DLL (measured 20 KB → 64 KB, 1 → 20 BAML entries).
- **Corrected CLAUDE.md**: the claim that `dotnet build` cannot generate WPF `.g.cs` on .NET Framework is false — a clean-tree build was verified to produce both the `.g.cs` and the BAML. The audit had flagged this as an open question.
- Added the `LOCUpcomingGamesTaggerProgressUpdating` string across all 19 locales.

## Renovate

Applied all three open Renovate PRs directly, since they conflict with the rewritten workflows: `actions/checkout` v6→v7 (#7), `upload-artifact` v6→v7 + `download-artifact` v7→v8 (#6), `release-downloader` v1.8→v1.13 (#4). All four tags verified to exist. **PRs #4, #6 and #7 can be closed once this merges.**

## Verification

- Clean-tree `dotnet build`: 0 warnings, 0 errors
- `dotnet test`: 25/25 passing
- CI validation logic (version consistency, PackageUrl, assembly version) executed locally against this commit: 0 errors, including a negative drift test
- Packaging leak re-checked with `Tests/bin` present: `Page` glob clean, DLL back to 22 KB

Version bumped to **1.1.0**; `extension.yaml` and `manifest.yaml` updated with changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: rebased onto master (PlayniteSDK 6.16.0)

The first CI run failed to restore. Root cause was **not** in this branch: Renovate PR #3 bumped `PlayniteSDK` 6.12.0 to 6.16.0 on master after this work started, and CI builds `refs/pull/8/merge`, so the merge combined master's 6.16.0 plugin reference with a test project pinning 6.12.0 - `NU1605` package downgrade.

Rebased onto current master. The test project now references **6.16.0**, matching the plugin, so the tests exercise the SDK that actually ships - the audit flagged the inverse ("tests run against a JSON library the plugin never runs against") on two sibling repos. `ExcludeAssets="runtime"` on the plugin's reference flows transitively and withholds `Playnite.SDK.dll` from the test host, so the reference is explicit rather than inherited; any future drift between the two fails restore loudly with NU1605 instead of passing silently.

**CI is green:** validate pass, build pass, 25/25 tests passing on the runner.

Verified the packaged output is exactly: `UpcomingGamesTagger.dll`, `.pdb`, `extension.yaml`, `icon.png`, and 19 `Localization/*.xaml` - no SDK or test binaries.

### One thing worth your call

`manifest.yaml` still declares `RequiredApiVersion: 6.12.0` while the plugin now compiles against SDK **6.16.0**. That drift arrived with Renovate #3 and predates this PR. I left it alone because raising it is a user-facing compatibility decision - it would raise the minimum Playnite version required to install. This plugin only uses long-stable APIs, so 6.12.0 is very likely still accurate, but the two no longer match by construction.
