### PR TITLE
Fix the Claude workflows: grant write access, gate to repo owner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write, not read: the action posts its review as a pull request comment. With
+      # read it runs to completion, is billed, and silently posts nothing.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,8 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write, not read: the action replies by posting a comment. With read it runs to
+      # completion, is billed, and silently posts nothing.
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,18 @@ on:
 
 jobs:
   claude:
+    # claude-code-action already refuses actors without write access, so this gate is
+    # about not spinning up a runner, and not spending the token, on a drive-by
+    # '@claude' mention from any GitHub user. issue_comment runs in the base repo
+    # context with secrets available, so without this the token is exposed to anyone
+    # who can open an issue.
     if: |
+      github.actor == 'sharkusmanch' && (
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +33,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
**Superseded in purpose by #10.** That PR landed `claude.yml` and `claude-code-review.yml` from the stock template, so this PR no longer adds them — it fixes two defects in what #10 merged. Rebased onto master.

## 1. The review runs, gets billed, and posts nothing

Both workflows declare `pull-requests: read` / `issues: read`, but the action posts its output **as a pull request comment**. It therefore cannot.

This is not theoretical — it already happened on #8 with the workflows exactly as merged:

```
Actor has write access: admin
"num_turns": 43
"total_cost_usd": 6.792634849999999
"permission_denials_count": 55
No buffered inline comments
```

The job reported **success** after 13m43s and **$6.79**, and left no comment, no review, nothing. A silent, billed no-op on every pull request.

`anthropics/claude-code-action`'s [setup guide](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md) requires `pull-requests: write` and `issues: write` for posting comments and reviews. Both are raised here.

`contents` is deliberately left at `read` — nothing here asks Claude to modify files, and the guide only requires `contents: write` for that.

## 2. `claude.yml` has no author gate

As merged it gates only on the comment text:

```yaml
if: |
  (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) || ...
```

`issue_comment` and `issues` events run in the **base repository context with secrets available**, so any GitHub user — no write access, no fork — can open an issue containing `@claude` and spend `CLAUDE_CODE_OAUTH_TOKEN`. At the ~$6.79/run seen above, that is a real bill.

This is the same Tier-1 finding the July 2026 code review raised against `playnite-media-audit`:

> **media-audit** `.github/workflows/claude.yml:15` — no author gate, unlike `claude-code-review.yml:12` which checks `comment.user.login == 'sharkusmanch'`. Any GitHub user can open an issue containing `@claude` and burn the `CLAUDE_CODE_OAUTH_TOKEN`.

It has since been fixed in media-audit; this applies the same fix so the repo does not re-inherit it. The condition is wrapped in `github.actor == 'sharkusmanch' && ( ... )`. `claude-code-action` already refuses actors without write access, so the gate is about not starting a runner and not spending the token in the first place — the log line `Checking permissions for actor` confirms the action's own check happens *after* billing has begun.

## Also

Both files pinned to `actions/checkout@v7` (they arrived at `v4`), matching what the rest of the repo moves to in #8.

## Deliberately left alone

`claude-code-review.yml` keeps triggering on `pull_request: [opened, synchronize, ready_for_review, reopened]`, giving automatic review on every PR. GitHub withholds secrets from fork pull requests, so it carries no equivalent exposure and the commented-out author filter is not needed.

## Note

This PR cannot demonstrate its own fix — for `pull_request` events the workflow runs from the **base** branch, so #8 and #9 are both still being reviewed by master's broken version until this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
